### PR TITLE
use pixbuf directly with a slice shell

### DIFF
--- a/source/ai.d
+++ b/source/ai.d
@@ -254,17 +254,7 @@ struct AI
 
       assert(session !is null);
 
-      Image img = new Image(
-         Picture.width,
-         Picture.height,
-         ImageFormat.IF_RGB,
-         BitDepth.BD_8,
-         cast(ubyte[])Picture.pixbuf.getPixelsWithLength()
-      );
-
-      scope(exit) destroy(img);
-
-      Slice!(ubyte*, 3) imSlice = img.sliced; // will be freed with the previous destroyFree(img)
+      Slice!(ubyte*, 3) imSlice = (cast(ubyte[])Picture.pixbuf.getPixelsWithLength()).sliced(Picture.height, Picture.width, 3);
 
       float scale;
       auto impr = letterBoxAndPreprocess(imSlice, scale);//preprocess(imSlice);


### PR DESCRIPTION
I did not test this. But it should work. Please test it before merging. imSlice will live as long as Picture.pixbuf is alive. sliced returns just a slice shell on the top of a regular d slice. No copy.

Slice!(ubyte*, 3) imSlice = (cast(ubyte[])Picture.pixbuf.getPixelsWithLength()).sliced(Picture.height, Picture.width, 3);

 If the pixbuff's life time is not long enough then make a gc allocated slice copy with:

Slice!(ubyte*, 3) imSlice = (cast(ubyte[])Picture.pixbuf.getPixelsWithLength()).sliced(Picture.height, Picture.width, 3).slice; // gc allocated duplication